### PR TITLE
fix: allow no-trailing newline after any directive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,77 @@ mod tests {
     }
 
     #[test]
-    fn test_no_line_ending() {
+    fn test_no_line_ending_after_module() {
+        let input = indoc! {r#"
+        module github.com/no-line-ending"#};
+
+        let go_mod = GoMod::from_str(input).unwrap();
+
+        assert_eq!(go_mod.module, "github.com/no-line-ending".to_string());
+    }
+
+    #[test]
+    fn test_no_line_ending_after_go() {
+        let input = indoc! {r#"
+        module github.com/no-line-ending
+
+        go 1.24"#};
+
+        let go_mod = GoMod::from_str(input).unwrap();
+
+        assert_eq!(go_mod.go, Some("1.24".to_string()));
+    }
+
+    #[test]
+    fn test_no_line_ending_after_godebug() {
+        let input = indoc! {r#"
+        module github.com/no-line-ending
+
+        godebug (
+            default=go1.21
+            panicnil=1
+        )"#};
+
+        let go_mod = GoMod::from_str(input).unwrap();
+
+        assert_eq!(
+            go_mod.godebug,
+            HashMap::from([
+                ("default".to_string(), "go1.21".to_string()),
+                ("panicnil".to_string(), "1".to_string())
+            ])
+        );
+    }
+
+    #[test]
+    fn test_no_line_ending_after_tool() {
+        let input = indoc! {r#"
+        module github.com/no-line-ending
+
+        tool example.com/mymodule/cmd/mytool1"#};
+
+        let go_mod = GoMod::from_str(input).unwrap();
+
+        assert_eq!(
+            go_mod.tool,
+            vec!["example.com/mymodule/cmd/mytool1".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_no_line_ending_after_toolchain() {
+        let input = indoc! {r#"
+        module github.com/no-line-ending
+
+        toolchain go1.21.1"#};
+
+        let go_mod = GoMod::from_str(input).unwrap();
+
+        assert_eq!(go_mod.toolchain, Some("go1.21.1".to_string()));
+    }
+
+    #[test]
+    fn test_no_line_ending_after_require() {
         let input = indoc! {r#"
         module github.com/no-line-ending
 
@@ -202,7 +272,6 @@ mod tests {
 
         let go_mod = GoMod::from_str(input).unwrap();
 
-        assert_eq!(go_mod.module, "github.com/no-line-ending".to_string());
         assert_eq!(
             go_mod.require,
             vec![ModuleDependency {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -55,14 +55,14 @@ fn comment<'a>(input: &mut &'a str) -> Result<Directive<'a>> {
 
 fn module<'a>(input: &mut &'a str) -> Result<Directive<'a>> {
     let res = preceded(("module", space1), take_till(1.., CRLF)).parse_next(input)?;
-    let _ = take_while(1.., CRLF).parse_next(input)?;
+    let _ = take_while(0.., CRLF).parse_next(input)?;
 
     Ok(Directive::Module(res))
 }
 
 fn go<'a>(input: &mut &'a str) -> Result<Directive<'a>> {
     let res = preceded(("go", space1), take_till(1.., CRLF)).parse_next(input)?;
-    let _ = take_while(1.., CRLF).parse_next(input)?;
+    let _ = take_while(0.., CRLF).parse_next(input)?;
 
     Ok(Directive::Go(res))
 }
@@ -102,14 +102,14 @@ fn godebug_multi(input: &mut &str) -> Result<Vec<(String, String)>> {
 
 fn tool<'a>(input: &mut &'a str) -> Result<Directive<'a>> {
     let res = preceded(("tool", space1), take_till(1.., CRLF)).parse_next(input)?;
-    let _ = take_while(1.., CRLF).parse_next(input)?;
+    let _ = take_while(0.., CRLF).parse_next(input)?;
 
     Ok(Directive::Tool(vec![res.to_owned()]))
 }
 
 fn toolchain<'a>(input: &mut &'a str) -> Result<Directive<'a>> {
     let res = preceded(("toolchain", space1), take_till(1.., CRLF)).parse_next(input)?;
-    let _ = take_while(1.., CRLF).parse_next(input)?;
+    let _ = take_while(0.., CRLF).parse_next(input)?;
 
     Ok(Directive::Toolchain(res))
 }

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -101,3 +101,18 @@ fn test_carriage_return() {
 
     assert_eq!(gomod.module, "github.com/klauspost/compress".to_string());
 }
+
+#[test]
+fn test_no_trailing_newline() {
+    let file_content = get_test_file_content("tool.mod").trim().to_string(); // remove trailing newline
+
+    let gomod = file_content.parse::<GoMod>().unwrap();
+
+    assert_eq!(
+        gomod.tool,
+        vec![
+            "example.com/mymodule/cmd/mytool1",
+            "example.com/mymodule/cmd/mytool2"
+        ]
+    );
+}


### PR DESCRIPTION
# User description
Fixes #18

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
module_("module"):::modified
take_while_("take_while"):::added
go_("go"):::modified
tool_("tool"):::modified
toolchain_("toolchain"):::modified
module_ -- "Allows zero or more trailing lines after module directive" --> take_while_
go_ -- "Allows zero or more trailing lines after go directive" --> take_while_
tool_ -- "Allows zero or more trailing lines after tool directive" --> take_while_
toolchain_ -- "Allows zero or more trailing lines after toolchain directive" --> take_while_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Updates the <code>gomod-parser</code> to correctly parse <code>go.mod</code> files where directives like <code>module</code>, <code>go</code>, <code>tool</code>, and <code>toolchain</code> might not be followed by a trailing newline. Modifies the <code>GoMod</code> parser to make the presence of a newline character after a directive optional, improving robustness for various <code>go.mod</code> file formats.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>milesj@users.noreply.g...</td><td>feat-Support-godebug-a...</td><td>June 25, 2025</td></tr>
<tr><td>anton.gruebel@gmail.com</td><td>refactor-upgrade-winno...</td><td>May 05, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/gomod-parser/21?tool=ast>(Baz)</a>.