### PR TITLE
chore: remove experimental env var for CodeQL

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,9 +11,6 @@ on:
 permissions:
   contents: read
 
-env:
-  CODEQL_ENABLE_EXPERIMENTAL_FEATURES: true # CodeQL support for Rust is experimental
-
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
# User description
- Rust is now official supported by CodeQL

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the CodeQL analysis workflow by removing the <code>CODEQL_ENABLE_EXPERIMENTAL_FEATURES</code> environment variable, reflecting the official support for Rust in CodeQL.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>anton.gruebel@gmail.com</td><td>chore-enable-CodeQL-9</td><td>May 11, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/gomod-parser/22?tool=ast>(Baz)</a>.