### PR TITLE
feat!: support go 1.24 ignore directives

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub struct GoMod {
     pub exclude: Vec<ModuleDependency>,
     pub replace: Vec<ModuleReplacement>,
     pub retract: Vec<ModuleRetract>,
+    pub ignore: Vec<String>,
 }
 
 impl std::str::FromStr for GoMod {
@@ -73,6 +74,7 @@ impl std::str::FromStr for GoMod {
                 Directive::Exclude(d) => res.exclude.append(d),
                 Directive::Replace(d) => res.replace.append(d),
                 Directive::Retract(d) => res.retract.append(d),
+                Directive::Ignore(d) => res.ignore.append(d),
             }
         }
 
@@ -282,6 +284,80 @@ mod tests {
                 indirect: false
             }]
         );
+    }
+
+    #[test]
+    fn test_ignore_single() {
+        let input = indoc! {r#"
+        module github.com/ignore-single
+
+        go 1.24
+
+        ignore ./testdata
+        "#};
+
+        let go_mod = GoMod::from_str(input).unwrap();
+
+        assert_eq!(go_mod.ignore, vec!["./testdata".to_string()]);
+    }
+
+    #[test]
+    fn test_ignore_multi() {
+        let input = indoc! {r#"
+        module github.com/ignore-multi
+
+        go 1.24
+
+        ignore (
+            ./testdata
+            ./vendor/temp
+            ./node_modules
+        )
+        "#};
+
+        let go_mod = GoMod::from_str(input).unwrap();
+
+        assert_eq!(
+            go_mod.ignore,
+            vec![
+                "./testdata".to_string(),
+                "./vendor/temp".to_string(),
+                "./node_modules".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_ignore_repeated_singles() {
+        let input = indoc! {r#"
+        module github.com/ignore-repeated
+
+        go 1.24
+
+        ignore ./testdata
+        ignore ./vendor/temp
+        "#};
+
+        let go_mod = GoMod::from_str(input).unwrap();
+
+        assert_eq!(
+            go_mod.ignore,
+            vec!["./testdata".to_string(), "./vendor/temp".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_no_line_ending_after_ignore() {
+        let input = indoc! {r#"
+        module github.com/no-line-ending
+
+        ignore (
+            ./testdata
+        )"#};
+
+        let go_mod = GoMod::from_str(input).unwrap();
+
+        assert_eq!(go_mod.ignore, vec!["./testdata".to_string()]);
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -22,6 +22,7 @@ pub(crate) enum Directive<'a> {
     Exclude(Vec<ModuleDependency>),
     Replace(Vec<ModuleReplacement>),
     Retract(Vec<ModuleRetract>),
+    Ignore(Vec<String>),
 }
 
 pub(crate) fn gomod<'a>(input: &mut &'a str) -> Result<Vec<Directive<'a>>> {
@@ -44,6 +45,7 @@ fn directive<'a>(input: &mut &'a str) -> Result<Directive<'a>> {
         "exclude" => exclude,
         "replace" => replace,
         "retract" => retract,
+        "ignore" => ignore,
         _ => fail,
     )
     .parse_next(input)
@@ -293,4 +295,39 @@ fn retract_multi(input: &mut &str) -> Result<Vec<ModuleRetract>> {
     let _ = (")", multispace0).parse_next(input)?;
 
     Ok(res.into_iter().flatten().collect::<Vec<ModuleRetract>>())
+}
+
+fn ignore<'a>(input: &mut &'a str) -> Result<Directive<'a>> {
+    let res = preceded(
+        ("ignore", space1),
+        dispatch! {peek(any);
+            '(' => ignore_multi,
+            _ => ignore_single,
+        },
+    )
+    .parse_next(input)?;
+    let _ = take_while(0.., CRLF).parse_next(input)?;
+
+    Ok(Directive::Ignore(res))
+}
+
+fn ignore_single(input: &mut &str) -> Result<Vec<String>> {
+    // terminate, if `)` is found
+    peek(not(')')).parse_next(input)?;
+
+    let path = take_till(1.., WHITESPACES).parse_next(input)?;
+
+    // remove any comments added to the same line
+    let _ = opt(comment).parse_next(input)?;
+
+    Ok(vec![path.to_string()])
+}
+
+fn ignore_multi(input: &mut &str) -> Result<Vec<String>> {
+    let _ = ("(", multispace1).parse_next(input)?;
+    let res: Vec<Vec<String>> =
+        repeat(1.., terminated(ignore_single, multispace0)).parse_next(input)?;
+    let _ = (")", multispace0).parse_next(input)?;
+
+    Ok(res.into_iter().flatten().collect::<Vec<String>>())
 }

--- a/tests/data/ignore.mod
+++ b/tests/data/ignore.mod
@@ -1,0 +1,11 @@
+module github.com/example/ignore
+
+go 1.24
+
+ignore ./build
+
+ignore (
+    ./testdata
+    ./vendor/temp
+    ./node_modules
+)

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -92,6 +92,23 @@ fn test_parse_tool() {
 }
 
 #[test]
+fn test_parse_ignore() {
+    let file_content = get_test_file_content("ignore.mod");
+    let gomod = file_content.parse::<GoMod>().unwrap();
+
+    assert_eq!(gomod.module, "github.com/example/ignore".to_string());
+    assert_eq!(
+        gomod.ignore,
+        vec![
+            "./build".to_string(),
+            "./testdata".to_string(),
+            "./vendor/temp".to_string(),
+            "./node_modules".to_string(),
+        ]
+    );
+}
+
+#[test]
 fn test_carriage_return() {
     let file_content = get_test_file_content("compress.mod")
         .replace("\r", "") // Replace any current CR


### PR DESCRIPTION
# User description
This pull request adds support for parsing the new `ignore` directive in Go module files added in Go 1.24

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add <code>ignore</code> directive handling to the Go module parser by wiring the new field into <code>GoMod::from_str</code> and returning parsed ignore paths from the directive dispatch. Update parser logic and supporting sample data to read single/multi-line <code>ignore</code> blocks and verify that <code>GoMod</code> reports the expected ignored paths.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/baz-scm/gomod-parser/35?tool=ast&topic=Ignore+parsing>Ignore parsing</a>
        </td><td>Add parser handling for <code>ignore</code> directives so that the module parser captures single and parenthesized ignore blocks, records them on the <code>GoMod</code> struct, and accepts directives at the end of files.<details><summary>Modified files (3)</summary><ul><li>src/lib.rs</li>
<li>src/parser.rs</li>
<li>tests/data/ignore.mod</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/baz-scm/gomod-parser/35?tool=ast&topic=Ignore+tests>Ignore tests</a>
        </td><td>Expand tests to cover <code>ignore</code> directives, including parser unit tests and data file scenarios to ensure the new field is populated as expected.<details><summary>Modified files (2)</summary><ul><li>src/lib.rs</li>
<li>tests/parse.rs</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/baz-scm/gomod-parser/35?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>