### PR TITLE
fix: install rust in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,9 @@ jobs:
     environment: release
     steps:
       - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '.github/**'
-      - '.pre-commit-config.yaml'
+    paths:
+      - '**'
+      - '!.github/**'
+      - '.github/workflows/release.yml'
+      - '!.pre-commit-config.yaml'
 
 permissions:
   contents: read


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Expand the release workflow trigger to fire on every push to <code>main</code> while still excluding GitHub config files so the pipeline runs consistently. Install <code>actions-rust-lang/setup-rust-toolchain</code> before <code>cargo-release</code> so the workflow always has the stable Rust toolchain available.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/baz-scm/gomod-parser/37?tool=ast&topic=Release+trigger+scope>Release trigger scope</a>
        </td><td>Adjust the release workflow push trigger to include all <code>main</code> updates while still ignoring GitHub workflow and pre-commit files so the pipeline activates reliably.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/release.yml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>anton.gruebel@gmail.com</td><td>change release trigger</td><td>May 25, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/baz-scm/gomod-parser/37?tool=ast&topic=Rust+toolchain+setup>Rust toolchain setup</a>
        </td><td>Install <code>actions-rust-lang/setup-rust-toolchain</code> with the stable channel before invoking <code>cargo-release</code> so the pipeline has Rust ready for publication steps.<details><summary>Modified files (1)</summary><ul><li>.github/workflows/release.yml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>anton.gruebel@gmail.com</td><td>change release trigger</td><td>May 25, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/baz-scm/gomod-parser/37?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>