### PR TITLE
chore: use client-id for app token generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.CI_GITHUB_APP_ID }}
+          client-id: ${{ vars.CI_GITHUB_CLIENT_ID }}
           private-key: ${{ secrets.CI_GITHUB_APP_PRIVATE_KEY }}
       - uses: googleapis/release-please-action@v5
         id: release


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the release workflow's GitHub Actions to use the app <code>client-id</code> when generating tokens so release-please can authenticate with the GitHub App configuration. Maintain the existing <code>private-key</code> secret to preserve token creation security.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>anton.gruebel@gmail.com</td><td>use client-id for app ...</td><td>May 27, 2026</td></tr></table></details>
<sub><a href="https://baz.co/changes/baz-scm/gomod-parser/39?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>